### PR TITLE
feat(csc): enable native smart call and hiya globally

### DIFF
--- a/unica/mods/csc/customize.sh
+++ b/unica/mods/csc/customize.sh
@@ -45,6 +45,9 @@ while read -r FILE; do
         SET_CSC_FEATURE_CONFIG "CscFeature_Setting_SupportMenuSmartTutor" "FALSE"
         SET_CSC_FEATURE_CONFIG "CscFeature_Setting_ConfigLongPressType" 1
         SET_CSC_FEATURE_CONFIG "CscFeature_Common_DisableBixby" --delete
+        SET_CSC_FEATURE_CONFIG "CscFeature_Contact_EnableSmartCall" "TRUE"
+        SET_CSC_FEATURE_CONFIG "CscFeature_Setting_ConfigOperatorCallService" "TRUE"
+        SET_CSC_FEATURE_CONFIG "CscFeature_Common_ConfigHiyaService" "TRUE"
         LOG_STEP_OUT
 
         LOG "- Encoding $FILE"


### PR DESCRIPTION
### Description
This PR force-enables native **Smart Call (Spam Identification)** and **Hiya** services globally within the `customize.sh` script.

### Why is this needed?
Users on Middle Eastern CSCs (such as **MID** or **THR**) currently lose these features unless they switch to regions like `THL` or `XXV`. However, switching to those regions often breaks the dialer's phone number formatting (causing joined/grouped numbers) due to **Shipping CSC** constraints in the bootloader.

By enabling these flags globally in the ROM's customization layer, users can:
1. Keep their native, well-formatted regional dialer (e.g., on MID).
2. Access full spam protection and caller ID features provided by Hiya.

### Changes:
- Added `CscFeature_Contact_EnableSmartCall` as TRUE.
- Added `CscFeature_Setting_ConfigOperatorCallService` as TRUE.
- Added `CscFeature_Common_ConfigHiyaService` as TRUE.

Verified on my S20 FE (Exynos 990) running the latest build.